### PR TITLE
Fix typo in Multiple section of README.md

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -82,7 +82,7 @@ end
 
 ```ruby
 class Person < ActiveRecord::Base
-  validates :mobile, :phone_number => {:ten_digits => true, :seven_digits => true, :allow_blank => true, :message => "Phone number must be either seven or digits in length, or blank."}
+  validates :mobile, :phone_number => {:ten_digits => true, :seven_digits => true, :allow_blank => true, :message => "Phone number must be either seven or ten digits in length, or blank."}
 end
 ```
 


### PR DESCRIPTION
Hi @travisjeffery!  :wave:  This PR fixes a typo in the message for the `Multiple` example of the README.  It looks like the message might be missing the word "ten."

Feel free to make changes to this branch if there are other changes that need to be made!  :smiley: